### PR TITLE
Interpolate: Backfill nans at beginning of ts

### DIFF
--- a/scripts/signal_marker_processing/pre_processors.py
+++ b/scripts/signal_marker_processing/pre_processors.py
@@ -549,7 +549,9 @@ class interpolator(base_pre_processor) :
                 
             for component in self.components :
                 ots = pd.Series(index=dates, data = ts[signal][component].values)
-                its = ots.resample('%dD' % self.Ts).mean().interpolate(method=self.method)
+                its = ots.resample('%dD' % self.Ts).mean().interpolate(
+                    method=self.method, limit_direction="both"
+                )
                 out_data.append(its)
                 compo_names.append( signal + '_' + component)
                 


### PR DESCRIPTION
Fix #26

This makes sure that interpolation also works for sparse time series with nans at the beginning. Example:

```
array([307.35974121, 307.35974121, 307.35974121, 307.35974121,
       307.35974121, 307.35974121, 307.35974121, 307.35974121,
       307.35974121, 307.35974121, 307.35974121, 307.35974121,
       307.35974121, 307.35974121, 307.35974121, 307.35974121,
       307.35974121, 307.35974121, 307.35974121, 307.35974121,
       307.35974121, 307.35974121, 298.75695583, 290.15417045,
       281.55138506, 272.94859968, 264.3458143 , 255.74302891,
       247.14024353, 263.82520549, 280.51016744, 297.19512939,
       294.65074851, 292.10636763, 289.56198675, 287.01760587,
       284.47322499, 281.92884411, 279.38446322, 276.84008234,
       274.29570146, 271.75132058, 269.2069397 , 266.66255882,
       264.11817793, 261.57379705, 259.02941617, 256.48503529,
       253.94065441, 251.39627353, 248.85189264, 246.30751176,
       243.76313088, 241.21875   , 244.45207596, 247.68540192,
       250.91872787, 254.15205383, 257.38537979, 260.61870575,
       263.85203171, 267.08535767, 266.35974808, 265.63413849,
       264.9085289 , 264.18291931, 263.45730972, 262.73170013,
       262.00609055, 261.28048096, 260.55487137, 259.82926178,
       259.10365219, 258.3780426 , 257.65243301, 256.92682343,
       256.20121384, 255.47560425, 254.74999466, 254.02438507,
       253.29877548, 252.57316589, 255.13048096, 257.68779602,
       260.24511108, 262.80242615, 265.35974121, 272.71584473,
       280.07194824, 287.42805176, 294.78415527, 302.14025879,
       308.94220947, 315.74416016, 322.54611084, 329.34806152,
       336.15001221, 342.95196289, 349.75391357, 356.55586426,
       363.35781494, 370.15976563, 376.96171631, 383.76366699,
       390.56561768, 397.36756836, 404.16951904, 410.97146973,
       417.77342041, 424.57537109, 431.37732178, 438.17927246,
       444.98122314, 451.78317383, 458.58512451, 465.3870752 ,
       472.18902588, 476.42438965, 480.65975342, 484.89511719,
       489.13048096, 493.36584473, 497.6012085 , 501.83657227,
       506.07193604, 510.3072998 , 514.54266357, 525.10781583,
       535.67296808, 546.23812034, 556.80327259, 567.36842485,
       577.9335771 , 588.49872936, 599.06388161, 609.62903387,
       620.19418612, 630.75933838, 641.32449063, 651.88964289,
       662.45479514, 673.0199474 , 683.58509965, 694.15025191,
       704.71540416, 715.28055642, 725.84570867, 736.41086093,
       746.97601318, 726.80515544, 706.63429769, 686.46343994,
       693.94025879, 701.41707764, 708.89389648, 716.37071533,
       723.84753418, 709.91827393, 695.98901367, 682.05975342,
       668.13049316, 654.20123291, 640.74268799, 627.28414307,
       613.82559814, 600.36705322, 586.9085083 , 569.68502808,
       552.46154785, 549.76888483, 547.07622181, 544.38355879,
       541.69089577, 538.99823275, 536.30556974, 533.61290672,
       530.9202437 , 528.22758068, 525.53491766, 522.84225464,
       520.14959162, 517.4569286 , 514.76426558, 512.07160256,
       509.37893954, 506.68627652, 503.9936135 , 501.30095048,
       498.60828746, 495.91562445, 493.22296143, 490.53029841,
       487.83763539, 485.14497237, 482.45230935, 479.75964633,
       477.06698331, 474.37432029, 471.68165727, 468.98899425,
       466.29633123, 463.60366821, 481.52440186, 499.4451355 ,
       517.36586914, 535.28660278, 553.20733643, 563.47075195,
       573.73416748, 583.99758301, 594.26099854, 604.52441406,
       615.4834246 , 626.44243513, 637.40144566, 648.36045619,
       659.31946673, 670.27847726, 681.23748779, 681.23748779,
       681.23748779, 681.23748779, 681.23748779, 681.23748779,
       681.23748779, 681.23748779, 681.23748779, 681.23748779,
       681.23748779, 681.23748779, 681.23748779, 681.23748779,
       681.23748779, 681.23748779, 681.23748779, 681.23748779,
       681.23748779, 681.23748779, 681.23748779, 681.23748779,
       681.23748779, 681.23748779, 681.23748779, 681.23748779,
       681.23748779, 681.23748779, 681.23748779, 681.23748779,
       681.23748779, 681.23748779, 681.23748779, 681.23748779,
       681.23748779, 681.23748779, 681.23748779, 681.23748779,
       681.23748779, 681.23748779, 681.23748779, 681.23748779,
       681.23748779, 681.23748779, 681.23748779, 681.23748779,
       681.23748779, 681.23748779, 681.23748779, 681.23748779,
       681.23748779, 681.23748779])
```