### PR TITLE
Label lengths for target fields adjusted for long UA group IDs

### DIFF
--- a/iacs_qa/sample_extraction/JRC_v2_notebook/JRC_extract_samples_notebook.ipynb
+++ b/iacs_qa/sample_extraction/JRC_v2_notebook/JRC_extract_samples_notebook.ipynb
@@ -24,6 +24,13 @@
     "\n",
     "**Version 2 (Jupyter Notebook)**\n",
     "\n",
+    "---\n",
+    "**Latest update: May 16th**\n",
+    "* Modified parts of the UI so it manages long UA group names better \n",
+    "* Parcel IDs in the parcel CSV file can now be either integers or strings \n",
+    "* Fixed manual target setting\n",
+    "---\n",
+    "\n",
     "The solution is still in its beta testing phase. Implementation of some of the expected features and general optimization is planned for the upcoming weeks.\n",
     "\n",
     "Recent changes:\n",
@@ -142,7 +149,7 @@
     "\n",
     "| **Column name** | **Type** | **Description** | **Comments** |\n",
     "| --------------- | -------- | --------------- | ------------ |\n",
-    "| gsa_par_id | string (text) | Parcel ID | |\n",
+    "| gsa_par_id | integer (whole number) or string (text) | Parcel ID | |\n",
     "| gsa_hol_id | integer (whole number) | Holding ID | |\n",
     "| ua_grp_id | string (text) | UA group ID | |\n",
     "| covered | integer (whole number) | Is the parcel covered by a HR image? (1 - yes, 0 - no) | Can only contain 0 or 1 |\n",
@@ -218,7 +225,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9b1cb9a4315d4793bacbb12c63e17cfe",
+       "model_id": "8003909b4a314713a87e83b113dbb7ca",
        "version_major": 2,
        "version_minor": 0
       },
@@ -320,7 +327,9 @@
     "\n",
     "#### **Target cutoff value**\n",
     "\n",
-    "The *Target cutoff* field can be used to define a cutoff value for all target values at once. Putting a value in the field and clicking *Recalculate* adjusts all the target values so that none of them exceeds the cutoff value."
+    "The *Target cutoff* field can be used to define a cutoff value for all target values at once. Putting a value in the field and clicking *Recalculate* adjusts all the target values so that none of them exceeds the cutoff value.\n",
+    "\n",
+    "If the UA group's name is truncated due to its length, hover your mouse over it to see the full name."
    ]
   },
   {
@@ -331,7 +340,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5b52d02bc7c74a15be2dab9c5e9239e7",
+       "model_id": "a2803970548b40479e9fe532669ab963",
        "version_major": 2,
        "version_minor": 0
       },
@@ -476,12 +485,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a03726871c2e46a6b422f477b30b8bbb",
+       "model_id": "10a7c4de610845598cb8aa0f094261ba",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "GridBox(children=(VBox(children=(HBox(children=(Label(value='Bucket: E5', _dom_classes=('orange_label_bold',))…"
+       "GridBox(children=(VBox(children=(HBox(children=(Label(value='1. E5', tooltip='E5', _dom_classes=('orange_label…"
       ]
      },
      "metadata": {},
@@ -505,7 +514,7 @@
     "buckets = sample_extraction.prepare_buckets(dm.ua_groups)\n",
     "parcels = sample_extraction.prepare_input_dataframe(dm.parcels_df)\n",
     "\n",
-    "widgets = gui.display_output_area(buckets)\n",
+    "widgets = gui.display_output_area(buckets, dm)\n",
     "\n",
     "sample_extraction.iterate_over_interventions(parcels, buckets, widgets)\n",
     "\n",

--- a/iacs_qa/sample_extraction/JRC_v2_notebook/modules/data_manager.py
+++ b/iacs_qa/sample_extraction/JRC_v2_notebook/modules/data_manager.py
@@ -20,6 +20,7 @@ class DataManager:
         self.parcels_path = parcels_path
         self.targets_path = targets_path
         self.ua_groups = {}
+        # ua_group_dict[group] = {"target" : 300, "count" : ua_group_count[group], "desc" : create_ua_group_description(group, counter)}
         self.parcel_file_loaded = False
         self.target_values_state = "(Target values loaded from the parcel file.)"
         self.parcels_df = None

--- a/iacs_qa/sample_extraction/JRC_v2_notebook/modules/gui.py
+++ b/iacs_qa/sample_extraction/JRC_v2_notebook/modules/gui.py
@@ -13,17 +13,24 @@ display(HTML(define_infobutton_style()))
 def target_widgets_on_value_change(change, datamanager): # controls gui behavior - stays in gui.py
     datamanager.target_values_state = f"(Target values were manually modified. Last change: {change['owner'].description} field changed to {change['new']}.)"
     datamanager.target_source_label.value = datamanager.target_values_state
+    get_target_values_from_widgets(datamanager.target_widgets_list, datamanager)
+
+def get_group_id_based_on_widget_description(description, datamanager):
+    for group, info in datamanager.ua_groups.items():
+        if info["desc"] == description:
+            return group
 
 def get_target_values_from_widgets(widgets_list, datamanager): # controls gui behavior - stays in gui.py
     for widget_box in widgets_list:
         widget = widget_box.children[0]
-        datamanager.ua_groups[widget.description]["target"] = widget.value
+        datamanager.ua_groups[get_group_id_based_on_widget_description(widget.description,datamanager)]["target"] = widget.value
 
 def create_target_widgets(datamanager):
     widget_list = []
     for group, info in datamanager.ua_groups.items():
         target = info["target"]
         count = info["count"]
+        desc = info["desc"]
         if target > count:
             target = count
 
@@ -31,10 +38,10 @@ def create_target_widgets(datamanager):
             value=target,
             min=0,
             max=int(1e10),
-            description=group,
+            description=desc,
             layout=widgets.Layout(width="150px"),
-            style={"description_width": "initial"}
-            
+            style={"description_width": "initial"},
+            tooltip=group
         )
         entry.observe(lambda change, dm=datamanager: target_widgets_on_value_change(change, dm), names='value')
 
@@ -42,7 +49,15 @@ def create_target_widgets(datamanager):
 
         group_box = widgets.HBox([entry, count_label])
         widget_list.append(group_box)
+    datamanager.target_widgets_list = widget_list
     return widget_list
+
+def create_ua_group_description(group_id, counter):
+    limit = 9
+    if len(group_id) > limit:
+        group_id = group_id[:limit] + "..."
+    
+    return f"{counter}. {group_id}"
 
 def get_ua_groups_from_parcel_file(parcels_df):
     """
@@ -54,13 +69,14 @@ def get_ua_groups_from_parcel_file(parcels_df):
     ua_groups = parcels_df["ua_grp_id"].unique()
     ua_group_count = parcels_df["ua_grp_id"].value_counts().to_dict()
     ua_group_dict = {}
+    counter = 1
     for group in ua_groups:
-        ua_group_dict[group] = {"target" : 300, "count" : ua_group_count[group]}
+        ua_group_dict[group] = {"target" : 300, "count" : ua_group_count[group], "desc" : create_ua_group_description(group, counter)}
+        counter += 1
     return ua_group_dict
         #PARAMETERS["ua_groups"][group] = {"target" : 300, "count" : ua_group_count[group]}
 
-
-def populate_target_values(target_df, widgets_list):
+def populate_target_values(target_df, widgets_list, datamanager):
     """
     Populate the values of target widgets using a dataframe that contains target values.
 
@@ -73,7 +89,7 @@ def populate_target_values(target_df, widgets_list):
         target = row["target"]
         for widget_box in widgets_list:
             widget = widget_box.children[0]
-            if widget.description == ua_group:
+            if widget.description == datamanager.ua_groups[ua_group]["desc"]:
                 widget.value = target
                 break
 
@@ -140,7 +156,7 @@ def load_target_file(b, entry_widget, output_area, widgets_list, datamanager):
         try:
             df = pd.read_csv(file_path)
             verify_target_df(df)
-            populate_target_values(df, widgets_list)
+            populate_target_values(df, widgets_list, datamanager)
             compare_bucket_lists(datamanager.ua_groups, df)
             datamanager.target_values_state = "(Target values loaded from the targets file.)"
             datamanager.target_source_label.value = datamanager.target_values_state
@@ -167,7 +183,7 @@ def display_parcel_input_config(datamanager):
     output_area = widgets.Output()
     parcel_file_load_button.unobserve_all()
     parcel_file_load_button.on_click(lambda b: load_parcel_file(parcel_file_path_entry, output_area, datamanager))
-    
+      
     hbox = widgets.HBox([parcel_info_button, parcel_file_path_entry, parcel_file_load_button])
     vbox = widgets.VBox([hbox, output_area])
     display(vbox)
@@ -256,13 +272,14 @@ def display_advanced_config():
     display(config_box)
 
 
-def display_output_area(buckets):
+def display_output_area(buckets, datamanager):
 
     # display(HTML("<style>.red_label { color:red }</style>"))
     # l = Label(value="My Label")
     # l.add_class("red_label")
     # display(l)
     vbox_list = []
+    dm = datamanager
 
     display(HTML("<style>.orange_label { color:orange }</style>"))
     display(HTML("<style>.orange_label_bold { color:orange; font-weight: bold }</style>"))
@@ -273,7 +290,8 @@ def display_output_area(buckets):
 
 
     for bucket_id, bucket in buckets.items():
-        header_label = widgets.Label(value=f"Bucket: {bucket_id}")
+        header_label_text = dm.ua_groups[bucket_id]["desc"]
+        header_label = widgets.Label(value=header_label_text, tooltip=bucket_id)
         if bucket["target"] == 0:
             header_label.add_class("green_label_bold")
             progress_value = 1

--- a/iacs_qa/sample_extraction/JRC_v2_notebook/modules/gui.py
+++ b/iacs_qa/sample_extraction/JRC_v2_notebook/modules/gui.py
@@ -34,14 +34,16 @@ def create_target_widgets(datamanager):
         if target > count:
             target = count
 
+        # set the boundedintext widget's input field width to 100px
         entry = widgets.BoundedIntText(
             value=target,
             min=0,
             max=int(1e10),
             description=desc,
-            layout=widgets.Layout(width="150px"),
-            style={"description_width": "initial"},
-            tooltip=group
+            layout=widgets.Layout(width="200px"),
+            style={"description_width": "65%", "font_family": "monospace"},
+            tooltip=group,
+            max_width = "50px"
         )
         entry.observe(lambda change, dm=datamanager: target_widgets_on_value_change(change, dm), names='value')
 
@@ -53,9 +55,12 @@ def create_target_widgets(datamanager):
     return widget_list
 
 def create_ua_group_description(group_id, counter):
-    limit = 9
+    limit = 20
     if len(group_id) > limit:
         group_id = group_id[:limit] + "..."
+    # else:
+    #     # add spaces to the end of the string to make all descriptions the same length
+    #     group_id = group_id + " " * (limit - len(group_id))
     
     return f"{counter}. {group_id}"
 
@@ -219,7 +224,7 @@ def display_bucket_targets_config(datamanager):
         target_cutoff_recalculate_button.on_click(lambda b: recalculate_targets_based_on_threshold(target_cutoff_entry, widgets_list, datamanager))
 
         hbox0 = widgets.HBox([target_source_label])
-        grid = widgets.GridBox(widgets_list, layout=widgets.Layout(grid_template_columns="repeat(3, 300px)", padding="10px"))
+        grid = widgets.GridBox(widgets_list, layout=widgets.Layout(grid_template_columns="repeat(3, 350px)", padding="10px"))
         hbox1 = widgets.HBox([target_file_path_entry, target_file_load_button,target_info_button], layout=widgets.Layout(padding="10px"))
         hbox2 = widgets.HBox([target_cutoff_entry, target_cutoff_recalculate_button, target_cutoff_info_button], layout=widgets.Layout(padding="10px"))
         vbox = widgets.VBox([hbox0, grid, hbox1, hbox2, output_area])
@@ -295,12 +300,12 @@ def display_output_area(buckets, datamanager):
         if bucket["target"] == 0:
             header_label.add_class("green_label_bold")
             progress_value = 1
-            progress_label = widgets.Label(value=f"Completed: {progress_value:.2%} ( {len(bucket['parcels'])} / {bucket['target']} )")
+            progress_label = widgets.Label(value=f"| Found: {progress_value:.2%} ( {len(bucket['parcels'])} / {bucket['target']} )")
             progress_label.add_class("green_label")
         else:
             header_label.add_class("orange_label_bold")
             progress_value = len(bucket["parcels"]) / bucket["target"]
-            progress_label = widgets.Label(value=f"Completed: {progress_value:.2%} ( {len(bucket['parcels'])} / {bucket['target']} )")
+            progress_label = widgets.Label(value=f"| Found: {progress_value:.2%} ( {len(bucket['parcels'])} / {bucket['target']} )")
             progress_label.add_class("orange_label")
         progress_bar = widgets.FloatProgress(
             value=progress_value,
@@ -313,7 +318,7 @@ def display_output_area(buckets, datamanager):
         hbox_header_progress = widgets.HBox([header_label, progress_label])
         vbox_list.append(widgets.VBox([hbox_header_progress, progress_bar]))
     
-    grid = widgets.GridBox(vbox_list, layout=widgets.Layout(grid_template_columns="repeat(3, 1fr)", padding="10px"))
+    grid = widgets.GridBox(vbox_list, layout=widgets.Layout(grid_template_columns="repeat(3, 1fr)", padding="5px"))
     display(grid)
     return grid
 
@@ -327,6 +332,6 @@ def update_output_area(buckets, grid):
         if len(bucket['parcels']) == bucket['target']:
             grid.children[i].children[0].children[0].add_class("green_label_bold")
             grid.children[i].children[0].children[1].add_class("green_label")
-        grid.children[i].children[0].children[1].value = f"Completed: {len(bucket['parcels']) / bucket['target']:.2%} ( {len(bucket['parcels'])} / {bucket['target']} )"
+        grid.children[i].children[0].children[1].value = f"| Found: {len(bucket['parcels']) / bucket['target']:.2%} ( {len(bucket['parcels'])} / {bucket['target']} )"
         grid.children[i].children[1].value = len(bucket['parcels']) / bucket['target']
         

--- a/iacs_qa/sample_extraction/JRC_v2_notebook/modules/sample_extraction.py
+++ b/iacs_qa/sample_extraction/JRC_v2_notebook/modules/sample_extraction.py
@@ -175,7 +175,7 @@ def iterate_over_interventions(parcel_df, buckets, progress_widgets): #, progres
     gui.update_output_area(buckets, progress_widgets)
     return buckets
 
-def intervention_loop(parcel_df, buckets, progress_widgets, checked_holdings, added_rows, full_buckets):
+def intervention_loop(parcel_df, buckets, progress_widgets, checked_holdings, added_rows, full_buckets, dm):
     for index, row in parcel_df.iterrows():
         
         if buckets_full(buckets):
@@ -211,9 +211,9 @@ def intervention_loop(parcel_df, buckets, progress_widgets, checked_holdings, ad
         # I hope this is not a problem, because the time savings with the new method are huge (43s vs 12s for Malta)
 
     gui.update_output_area(buckets, progress_widgets)
-    return buckets, new_full_bucket
+    return buckets, ""
 
-def iterate_over_interventions_v2(parcel_df, buckets, progress_widgets):
+def iterate_over_interventions_v2(parcel_df, buckets, progress_widgets, dm):
     """
     Main loop of the script.
     Iterates over the rows in the interventions dataframe and adds parcels to the buckets.
@@ -225,9 +225,10 @@ def iterate_over_interventions_v2(parcel_df, buckets, progress_widgets):
     added_rows = set()
     full_buckets = []
     while not buckets_full(buckets):
-        buckets, new_full_bucket = intervention_loop(parcel_df, buckets, progress_widgets, checked_holdings, added_rows, full_buckets)
-        full_buckets.append(new_full_bucket)
-        parcel_df = reduce_parcel_dataframe(parcel_df, new_full_bucket)
+        buckets, new_full_bucket = intervention_loop(parcel_df, buckets, progress_widgets, checked_holdings, added_rows, full_buckets, dm)
+        if new_full_bucket != "":
+            full_buckets.append(new_full_bucket)
+            parcel_df = reduce_parcel_dataframe(parcel_df, new_full_bucket)
 
     gui.update_output_area(buckets, progress_widgets)
     return buckets

--- a/iacs_qa/sample_extraction/JRC_v2_notebook/run_outside_notebook.py
+++ b/iacs_qa/sample_extraction/JRC_v2_notebook/run_outside_notebook.py
@@ -11,7 +11,7 @@ def extract_parcels_and_ua_groups(path):
     Extracts the parcels from the csv file and returns a dataframe and UA group dictionary.
     """
     try:
-        parcel_df = pd.read_csv(path)
+        parcel_df = pd.read_csv(path) 
         verify_parcel_df(parcel_df)
         ua_group_dict = get_ua_groups_from_parcel_file(parcel_df)
         logging.info("Parcel file verified successfully. Preview: \n%s", parcel_df.head())
@@ -21,7 +21,7 @@ def extract_parcels_and_ua_groups(path):
         raise
     except pd.errors.ParserError:
         logging.error("Parsing error while reading the file: %s", path)
-        raise
+        raise 
     except Exception as e:
         logging.error("Unexpected error loading parcel file: %s", e)
         raise
@@ -58,6 +58,5 @@ if __name__ == "__main__":
         logging.info("All files loaded successfully.")
     except Exception as e:
         logging.error("An error occurred: %s", e)
-
 
     


### PR DESCRIPTION
Upon noticing that for some countries UA group IDs are long, I had to rewrite some of the UI features.

- Fixed UI elements to adjust for potentially long UA group IDs
- Allowed Parcel IDs to be integers, as per Paolo's suggestion